### PR TITLE
Refactor: Simplify ClienteVeiculo relationship and add management API

### DIFF
--- a/ChallengeMuttuApi/ChallengeMuttuApi/Data/AppDbContext.cs
+++ b/ChallengeMuttuApi/ChallengeMuttuApi/Data/AppDbContext.cs
@@ -18,81 +18,81 @@ namespace ChallengeMuttuApi.Data
         /// <param name="options">Opções de configuração do DbContext.</param>
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
-        // 🔹 Todos os DbSets para suas tabelas principais
+        // DbSets para as entidades principais da aplicação.
 
         /// <summary>
-        /// Tabela dos boxex de entrada e saida dos conteiner. (Comentário baseado na sua imagem de erro)
+        /// Representa a coleção de Boxes (contêineres ou locais de armazenamento) no banco de dados.
         /// </summary>
         public DbSet<Box> Boxes { get; set; }
         /// <summary>
-        /// Representa a coleção de Clientes no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Clientes no banco de dados.
         /// </summary>
         public DbSet<Cliente> Clientes { get; set; }
         /// <summary>
-        /// Representa a coleção de Contatos no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Contatos (informações de contato) no banco de dados.
         /// </summary>
         public DbSet<Contato> Contatos { get; set; }
         /// <summary>
-        /// Representa a coleção de Endereços no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Endereços no banco de dados.
         /// </summary>
         public DbSet<Endereco> Enderecos { get; set; }
         /// <summary>
-        /// Representa a coleção de Pátios no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Pátios (áreas de armazenamento ou operação) no banco de dados.
         /// </summary>
         public DbSet<Patio> Patios { get; set; }
         /// <summary>
-        /// Representa a coleção de Rastreamentos no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Rastreamentos (informações de localização ou status) no banco de dados.
         /// </summary>
         public DbSet<Rastreamento> Rastreamentos { get; set; }
         /// <summary>
-        /// Representa a coleção de Veículos no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Veículos no banco de dados.
         /// </summary>
         public DbSet<Veiculo> Veiculos { get; set; }
         /// <summary>
-        /// Representa a coleção de Zonas no banco de dados. (Substitua pelo seu comentário original se diferente)
+        /// Representa a coleção de Zonas (setores ou divisões de pátios) no banco de dados.
         /// </summary>
         public DbSet<Zona> Zonas { get; set; }
 
-        // 🔹 DbSets para suas tabelas de ligação (models que representam as tabelas de junção)
+        // DbSets para as tabelas de ligação (entidades que modelam relacionamentos muitos-para-muitos).
 
         /// <summary>
-        /// Representa a coleção de ligações entre Clientes e Veículos. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Clientes e Veículos.
         /// </summary>
         public DbSet<ClienteVeiculo> ClienteVeiculos { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Contatos e Pátios. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Contatos e Pátios.
         /// </summary>
         public DbSet<ContatoPatio> ContatoPatios { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Endereços e Pátios. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Endereços e Pátios.
         /// </summary>
         public DbSet<EnderecoPatio> EnderecoPatios { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Pátios e Boxes. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Pátios e Boxes.
         /// </summary>
         public DbSet<PatioBox> PatioBoxes { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Veículos e Boxes. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Veículos e Boxes.
         /// </summary>
         public DbSet<VeiculoBox> VeiculoBoxes { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Veículos e Pátios. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Veículos e Pátios.
         /// </summary>
         public DbSet<VeiculoPatio> VeiculoPatios { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Veículos e Rastreamentos. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Veículos e Rastreamentos.
         /// </summary>
         public DbSet<VeiculoRastreamento> VeiculoRastreamentos { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Veículos e Zonas. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Veículos e Zonas.
         /// </summary>
         public DbSet<VeiculoZona> VeiculoZonas { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Zonas e Boxes. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Zonas e Boxes.
         /// </summary>
         public DbSet<ZonaBox> ZonaBoxes { get; set; }
         /// <summary>
-        /// Representa a coleção de ligações entre Zonas e Pátios. (Substitua pelo seu comentário original se diferente)
+        /// Representa a tabela de ligação entre Zonas e Pátios.
         /// </summary>
         public DbSet<ZonaPatio> ZonaPatios { get; set; }
 
@@ -106,20 +106,15 @@ namespace ChallengeMuttuApi.Data
         {
             base.OnModelCreating(modelBuilder);
 
-            // 🔹 Configuração de Chaves Compostas para Tabelas de Ligação
-            // Os comentários XML internos no OnModelCreating não são padrão e podem ser removidos se não desejados.
-            // Se mantidos, precisam estar corretamente posicionados para não causar CS1587.
-            // Para esta correção, vou remover os comentários XML internos do OnModelCreating,
-            // pois o erro CS1587 geralmente se aplica a membros de classe como propriedades (DbSet).
-
+            // Configuração das chaves primárias compostas para as tabelas de ligação (muitos-para-muitos).
+            // A entidade ClienteVeiculo utiliza uma chave composta pelos IDs de Cliente e Veículo.
             modelBuilder.Entity<ClienteVeiculo>()
                 .HasKey(cv => new {
                     cv.TbClienteIdCliente,
-                    cv.TbClienteTbEnderecoIdEndereco,
-                    cv.TbClienteTbContatoIdContato,
                     cv.TbVeiculoIdVeiculo
                 });
 
+            // Configuração dos relacionamentos para ClienteVeiculo.
             modelBuilder.Entity<ClienteVeiculo>()
                 .HasOne(cv => cv.Cliente)
                 .WithMany(c => c.ClienteVeiculos)
@@ -130,6 +125,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(v => v.ClienteVeiculos)
                 .HasForeignKey(cv => cv.TbVeiculoIdVeiculo);
 
+            // Configurações para ContatoPatio
             modelBuilder.Entity<ContatoPatio>()
                 .HasKey(cp => new { cp.TbPatioIdPatio, cp.TbContatoIdContato });
             modelBuilder.Entity<ContatoPatio>()
@@ -141,6 +137,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(c => c.ContatoPatios)
                 .HasForeignKey(cp => cp.TbContatoIdContato);
 
+            // Configurações para EnderecoPatio
             modelBuilder.Entity<EnderecoPatio>()
                 .HasKey(ep => new { ep.TbEnderecoIdEndereco, ep.TbPatioIdPatio });
             modelBuilder.Entity<EnderecoPatio>()
@@ -152,6 +149,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(p => p.EnderecoPatios)
                 .HasForeignKey(ep => ep.TbPatioIdPatio);
 
+            // Configurações para PatioBox
             modelBuilder.Entity<PatioBox>()
                 .HasKey(pb => new { pb.TbPatioIdPatio, pb.TbBoxIdBox });
             modelBuilder.Entity<PatioBox>()
@@ -163,6 +161,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(b => b.PatioBoxes)
                 .HasForeignKey(pb => pb.TbBoxIdBox);
 
+            // Configurações para VeiculoBox
             modelBuilder.Entity<VeiculoBox>()
                 .HasKey(vb => new { vb.TbVeiculoIdVeiculo, vb.TbBoxIdBox });
             modelBuilder.Entity<VeiculoBox>()
@@ -174,6 +173,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(b => b.VeiculoBoxes)
                 .HasForeignKey(vb => vb.TbBoxIdBox);
 
+            // Configurações para VeiculoPatio
             modelBuilder.Entity<VeiculoPatio>()
                 .HasKey(vp => new { vp.TbVeiculoIdVeiculo, vp.TbPatioIdPatio });
             modelBuilder.Entity<VeiculoPatio>()
@@ -185,6 +185,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(p => p.VeiculoPatios)
                 .HasForeignKey(vp => vp.TbPatioIdPatio);
 
+            // Configurações para VeiculoRastreamento
             modelBuilder.Entity<VeiculoRastreamento>()
                 .HasKey(vr => new { vr.TbVeiculoIdVeiculo, vr.TbRastreamentoIdRastreamento });
             modelBuilder.Entity<VeiculoRastreamento>()
@@ -196,6 +197,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(r => r.VeiculoRastreamentos)
                 .HasForeignKey(vr => vr.TbRastreamentoIdRastreamento);
 
+            // Configurações para VeiculoZona
             modelBuilder.Entity<VeiculoZona>()
                 .HasKey(vz => new { vz.TbVeiculoIdVeiculo, vz.TbZonaIdZona });
             modelBuilder.Entity<VeiculoZona>()
@@ -207,6 +209,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(z => z.VeiculoZonas)
                 .HasForeignKey(vz => vz.TbZonaIdZona);
 
+            // Configurações para ZonaBox
             modelBuilder.Entity<ZonaBox>()
                 .HasKey(zb => new { zb.TbZonaIdZona, zb.TbBoxIdBox });
             modelBuilder.Entity<ZonaBox>()
@@ -218,6 +221,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(b => b.ZonaBoxes)
                 .HasForeignKey(zb => zb.TbBoxIdBox);
 
+            // Configurações para ZonaPatio
             modelBuilder.Entity<ZonaPatio>()
                 .HasKey(zp => new { zp.TbPatioIdPatio, zp.TbZonaIdZona });
             modelBuilder.Entity<ZonaPatio>()
@@ -229,7 +233,7 @@ namespace ChallengeMuttuApi.Data
                 .WithMany(z => z.ZonaPatios)
                 .HasForeignKey(zp => zp.TbZonaIdZona);
 
-            // 🔹 Configuração de Índices Únicos usando Fluent API
+            // Configuração de Índices Únicos.
             modelBuilder.Entity<Cliente>()
                 .HasIndex(c => c.Cpf)
                 .IsUnique();
@@ -244,7 +248,7 @@ namespace ChallengeMuttuApi.Data
                 .HasIndex(v => v.Chassi)
                 .IsUnique();
 
-            // 🔹 Configurações adicionais de mapeamento
+            // Configurações adicionais de mapeamento de propriedades e conversões.
             modelBuilder.Entity<Cliente>()
                 .Property(c => c.EstadoCivil)
                 .HasConversion<string>();

--- a/ChallengeMuttuApi/ChallengeMuttuApi/Model/Cliente.cs
+++ b/ChallengeMuttuApi/ChallengeMuttuApi/Model/Cliente.cs
@@ -53,10 +53,10 @@ namespace ChallengeMuttuApi.Model
             get => _sexo;
             set
             {
-                // DDL CHECK (SEXO IN ('M', 'H', 'MH')) [cite: 43]
-                // O frontend envia 'M' ou 'F'. Ajuste se 'H' ou 'MH' forem cenários válidos.
+                // Valida e armazena o sexo. Aceita 'M' (Masculino), 'F' (Feminino), 
+                // 'H' (Outro/Não especificado), ou 'MH'.
                 string upperValue = value?.ToUpperInvariant() ?? string.Empty;
-                if (upperValue == "M" || upperValue == "F" || upperValue == "H" || upperValue == "MH") // Incluindo MH conforme DDL
+                if (upperValue == "M" || upperValue == "F" || upperValue == "H" || upperValue == "MH")
                     _sexo = upperValue;
                 else
                     throw new ArgumentException("Sexo inválido! Use 'M' (Masculino), 'F' (Feminino), 'H' (Outro/Não especificado) ou 'MH'.", nameof(Sexo));
@@ -69,7 +69,7 @@ namespace ChallengeMuttuApi.Model
         public required string Nome { get; set; }
 
         [Column("SOBRENOME")]
-        [Required(ErrorMessage = "O Sobrenome é obrigatório.")] // Adicionado Required baseado no DDL NOT NULL [cite: 5]
+        [Required(ErrorMessage = "O Sobrenome é obrigatório.")]
         [StringLength(100, ErrorMessage = "O Sobrenome deve ter no máximo 100 caracteres.")]
         public string Sobrenome { get; set; } // Inicializado no construtor
 
@@ -85,9 +85,10 @@ namespace ChallengeMuttuApi.Model
             get => _cpf;
             set
             {
-                // Limpa qualquer formatação (pontos, traços) antes de validar e armazenar
+                // Limpa qualquer formatação (pontos, traços) antes de validar e armazenar.
+                // Espera-se 11 dígitos numéricos.
                 var cleanedValue = new string((value ?? string.Empty).Where(char.IsDigit).ToArray());
-                if (cleanedValue.Length == 11) // Não precisa mais do .All(char.IsDigit) pois já filtramos
+                if (cleanedValue.Length == 11)
                     _cpf = cleanedValue;
                 else
                     throw new ArgumentException("CPF inválido! Deve conter 11 dígitos numéricos após remoção de formatação.", nameof(Cpf));
@@ -95,24 +96,23 @@ namespace ChallengeMuttuApi.Model
         }
 
         [Column("PROFISSAO")]
-        [Required(ErrorMessage = "A Profissão é obrigatória.")] // Adicionado Required baseado no DDL NOT NULL [cite: 5]
+        [Required(ErrorMessage = "A Profissão é obrigatória.")]
         [StringLength(50, ErrorMessage = "A Profissão deve ter no máximo 50 caracteres.")]
         public string Profissao { get; set; } // Inicializado no construtor
 
         [Column("ESTADO_CIVIL")]
         [Required(ErrorMessage = "O Estado Civil é obrigatório.")]
-        [StringLength(50)] // O EnumDataType já valida os valores, mas StringLength pode ser mantido
-        // [EnumDataType(typeof(EstadoCivil), ErrorMessage = "Estado civil inválido!")] // Esta validação é boa para model binding
-        public EstadoCivil EstadoCivil // A conversão para string é feita no AppDbContext
+        [StringLength(50)] 
+        // A conversão para string é feita no AppDbContext.
+        // O EnumDataType pode ser usado para validação no model binding, mas a validação principal ocorre no setter.
+        public EstadoCivil EstadoCivil 
         {
             get => _estadoCivil;
             set
             {
-                // A validação com Enum.IsDefined é boa se o tipo no banco for NUMBER e mapeado para int no C#.
-                // Como está mapeado para string no banco (VARCHAR2(50 CHAR)) e a conversão é feita no AppDbContext,
-                // o setter aqui pode apenas atribuir, confiando na conversão e na constraint do banco.
-                // No entanto, para consistência com seu código original, manteremos a validação.
-                if (!Enum.IsDefined(typeof(EstadoCivil), value)) // DDL CK_CLIENTE_ESTADO_CIVIL valida os valores string [cite: 44]
+                // Valida se o valor fornecido é um membro válido do enum EstadoCivil.
+                // A conversão para string para armazenamento no banco é configurada no AppDbContext.
+                if (!Enum.IsDefined(typeof(EstadoCivil), value))
                     throw new ArgumentException("Estado civil inválido!", nameof(EstadoCivil));
                 _estadoCivil = value;
             }

--- a/ChallengeMuttuApi/ChallengeMuttuApi/Model/ClienteVeiculo.cs
+++ b/ChallengeMuttuApi/ChallengeMuttuApi/Model/ClienteVeiculo.cs
@@ -7,11 +7,9 @@ namespace ChallengeMuttuApi.Model
     /// <summary>
     /// Representa a tabela de ligação "TB_CLIENTEVEICULO" no banco de dados.
     /// Estabelece o relacionamento muitos-para-muitos entre Cliente e Veículo.
-    /// A chave primária desta tabela é composta por uma combinação de IDs de Cliente, Endereço, Contato e Veículo.
+    /// A chave primária desta tabela é composta pela combinação do ID do Cliente e do ID do Veículo.
     /// <remarks>
-    /// OBS: O design da PK composta (CLIENTEVEICULO_PK) é incomum e pode exigir configuração explícita no DbContext.
-    /// A chave primária inclui o ID do Endereço e Contato do Cliente, o que não é padrão em relacionamentos
-    /// muitos-para-muitos típicos. Considere revisar o design do banco de dados se essa granularidade não for intencional.
+    /// Esta tabela agora utiliza uma chave primária composta padrão, formada por TB_CLIENTE_ID_CLIENTE e TB_VEICULO_ID_VEICULO.
     /// </remarks>
     /// </summary>
     [Table("TB_CLIENTEVEICULO")]
@@ -24,25 +22,6 @@ namespace ChallengeMuttuApi.Model
         [Column("TB_CLIENTE_ID_CLIENTE")]
         [Required]
         public int TbClienteIdCliente { get; set; }
-
-        /// <summary>
-        /// Obtém ou define o ID do Endereço do Cliente que faz parte da chave composta.
-        /// Mapeia para a coluna "TB_CLIENTE_TB_ENDERECO_ID_ENDERECO" (Parte da Chave Primária Composta).
-        /// Este campo é uma anomalia no DDL, pois a PK de TB_CLIENTE é apenas ID_CLIENTE.
-        /// Recomenda-se revisão do design do banco se esta complexidade não for intencional.
-        /// </summary>
-        [Column("TB_CLIENTE_TB_ENDERECO_ID_ENDERECO")]
-        [Required]
-        public int TbClienteTbEnderecoIdEndereco { get; set; }
-
-        /// <summary>
-        /// Obtém ou define o ID do Contato do Cliente que faz parte da chave composta.
-        /// Mapeia para a coluna "TB_CLIENTE_TB_CONTATO_ID_CONTATO" (Parte da Chave Primária Composta).
-        /// Este campo é uma anomalia no DDL, similar ao Endereço.
-        /// </summary>
-        [Column("TB_CLIENTE_TB_CONTATO_ID_CONTATO")]
-        [Required]
-        public int TbClienteTbContatoIdContato { get; set; }
 
         /// <summary>
         /// Obtém ou define o ID do Veículo que faz parte da chave composta.


### PR DESCRIPTION
This commit introduces several improvements to the ChallengeMuttuApi:

1.  **Simplified Cliente-Veiculo Relationship:**
    *   Refactored the `ClienteVeiculo` entity and its mapping in `AppDbContext` to use a standard composite primary key (`ClienteId`, `VeiculoId`), removing the previous complex key that included client's address and contact IDs. This simplifies the data model and aligns with best practices for many-to-many relationships.

2.  **New API Endpoints for Client-Vehicle Associations:**
    *   Added new endpoints to `ClientesController` to manage associations between clients and vehicles:
        *   `POST /api/clientes/{clienteId}/veiculos`: Associates vehicles with a client.
        *   `GET /api/clientes/{clienteId}/veiculos`: Retrieves a client's associated vehicles.
        *   `DELETE /api/clientes/{clienteId}/veiculos/{veiculoId}`: Dissociates a vehicle from a client.
    *   These endpoints include validation, error handling, and XML documentation.

3.  **Improved XML Documentation:**
    *   Reviewed and refined XML comments in `Cliente.cs`, `ClienteVeiculo.cs`, `AppDbContext.cs`, and for new API endpoints to ensure accuracy and completeness for Swagger documentation.
    *   Confirmed that XML documentation generation is enabled in the project.

4.  **Program.cs Enhancements:**
    *   Restricted Swagger UI (`app.UseSwagger`, `app.UseSwaggerUI`) to be available only in the Development environment to enhance security in production.
    *   Conditionalized the verbose custom CORS debug logging middleware to run only in the Development environment.
    *   Enabled HTTPS redirection (`app.UseHttpsRedirection()`) for improved security, with a comment advising on SSL certificate configuration.

These changes address structural issues in the data model, add missing functionality for relationship management, and improve the overall robustness and developer experience of the API.